### PR TITLE
`lastValue` is wrongly typed

### DIFF
--- a/src/inline-attachment.ts
+++ b/src/inline-attachment.ts
@@ -32,7 +32,7 @@ export default class InlineAttachment {
   private settings: InlineAttachmentSettings
   private editor: IEditor
   private filenameTag: string
-  private lastValue: string
+  private lastValue: string | null
 
   constructor(instance: IEditor, options: Partial<InlineAttachmentSettings>)
   {


### PR DESCRIPTION
in constructor

```ts
constructor(instance: IEditor, options: Partial<InlineAttachmentSettings>)
{
     this.lastValue = null;
```

the property says

```ts
private lastValue: string
```

resulting

```
ERROR in /path/to/project/node_modules/@ragg/inline-attachment/src/inline-attachment.ts
ERROR in /path/to/project/node_modules/@ragg/inline-attachment/src/inline-attachment.ts(42,5):
TS2322: Type 'null' is not assignable to type 'string'.
```